### PR TITLE
Run getPosition in background, since iOS keeps complaining about it

### DIFF
--- a/src/ios/ConnectSDKCordovaDispatcher.m
+++ b/src/ios/ConnectSDKCordovaDispatcher.m
@@ -529,10 +529,12 @@ static id orNull (id obj)
 
 - (void) mediaControl_getPosition:(JSCommand*)command
 {
-    id<MediaControl> mediaControl = [self getMediaControl:command];
-    if (!mediaControl) return;
-    
-    [mediaControl getPositionWithSuccess:command.successWithDouble failure:command.failure];
+    [command.plugin.commandDelegate runInBackground:^{
+      id<MediaControl> mediaControl = [self getMediaControl:command];
+      if (!mediaControl) return;
+
+      [mediaControl getPositionWithSuccess:command.successWithDouble failure:command.failure];
+    }];
 }
 
 - (void) mediaControl_getPlayState:(JSCommand*)command


### PR DESCRIPTION
It's apparently safe to run mediaControl_getPosition in the background.

Our app tracks the position every second, so the log was full of this:
THREAD WARNING: ['ConnectSDK'] took '12.222900' ms. Plugin should use a background thread.
